### PR TITLE
Correções de inglês e configuração no footer

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,4 @@
+author: perifaCode
 title: perifaCode - comunidade de programação da periferia
 email: contato@perifacode.com
 description: >- # this means to ignore newlines until "baseurl:"

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,5 +1,5 @@
 <footer class="main-footer">
-    <span>© {{ site.time | date: '%Y' }} writed with <3 by {{ site.author }}, site develop with <a href="https://jekyllrb.com/" title="Jekyll website">Jekyll</a></span>
+    <span>© {{ site.time | date: '%Y' }} written with <3 by {{ site.author }}, site development with <a href="https://jekyllrb.com/" title="Jekyll website">Jekyll</a></span>
 </footer>
 </body>
 {% if site.disqus_shortname %}


### PR DESCRIPTION
- Pequenos erros de inglês removidos do footer: `writed -> written`, `site develop -> site development`.
- Configura `site.author` como sendo `perifaCode`.

Footer após ambas mudanças:
![image](https://user-images.githubusercontent.com/25608481/63515112-73f96580-c4c0-11e9-83a6-796b12739614.png)